### PR TITLE
Fixes for search field

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilteducation/vuetify-admin",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "SPA admin framework for Vue.js running on top of REST APIs, built on Vuetify",
   "main": "dist/admin.common.js",
   "module": "src/index.js",

--- a/packages/admin/src/components/internal/FormFilter.vue
+++ b/packages/admin/src/components/internal/FormFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <form>
+  <form @submit.prevent>
     <v-row>
       <v-col sm="auto" v-for="(item, index) in filters" :key="index">
         <div class="d-flex align-center">

--- a/packages/admin/src/components/internal/InputFilter.vue
+++ b/packages/admin/src/components/internal/InputFilter.vue
@@ -62,7 +62,7 @@ export default {
   methods: {
     debounceInput: debounce(function () {
       this.$emit("input", this.input);
-    }, 200),
+    }, 500),
   },
 };
 </script>


### PR DESCRIPTION
The debounce time of 200ms is short and causes a lot of "extra" searches.

If you enter something in the search field and press enter, the page will reload. Fixed with a submit.prevent.